### PR TITLE
Skip host key verification.

### DIFF
--- a/lib/vagrant-teraterm/command.rb
+++ b/lib/vagrant-teraterm/command.rb
@@ -34,6 +34,8 @@ module VagrantTeraTerm
             "#{ssh_info[:port]}",
             "/ssh",
             "/2",
+            # skip host key verification
+            "/nosecuritywarning",
             "/user=#{ssh_info[:username]}"
         ]
 


### PR DESCRIPTION
I have implemented Tera Term version SSH host key verification skip code.:
- Tera Term: `/nosecuritywarning`
- OpenSSH: `StrictHostKeyChecking no`

vagrant ssh-config subcommand generate host key verification ignore code like following:

```
C:\path\to\vagrantfile>vagrant ssh-config
Host default
  HostName 127.0.0.1
  User vagrant
  Port 2222
  UserKnownHostsFile /dev/null
  StrictHostKeyChecking no
  PasswordAuthentication no
  IdentityFile C:/path/to/vagrantfile/.vagrant/machines/default/virtualbox/private_key
  IdentitiesOnly yes
  LogLevel FATAL
```
